### PR TITLE
Fix circuit definition to avoid singular matrices

### DIFF
--- a/guitarpedals/circuits.py
+++ b/guitarpedals/circuits.py
@@ -15,12 +15,17 @@ logger = setup_logging()
 def fuzz_circuit(dc_voltage=9@u_V):
     """Builds a simple fuzz pedal circuit using a transistor."""
     circuit = Circuit('Fuzz')
-    circuit.V(1, 'in', circuit.gnd, 0@u_V)
+    # The input node will be driven by the simulation function so we don't add
+    # a fixed DC source here. Having two voltage sources connected to the same
+    # node causes ngspice to fail with a singular matrix error.
     circuit.V(2, 'batt', circuit.gnd, dc_voltage)
     circuit.R(1, 'in', 'b', 33@u_kOhm)
     circuit.R(2, 'b', 'c', 100@u_kOhm)
     circuit.R(3, 'c', circuit.gnd, 10@u_kOhm)
     circuit.C(1, 'c', 'out', 0.1@u_uF)
+    # Provide a load so that the output node isn't left floating which can
+    # otherwise lead to a singular matrix during simulation.
+    circuit.R('load', 'out', circuit.gnd, 100@u_kOhm)
     circuit.BJT(1, 'c', 'b', circuit.gnd, model='npn')
     circuit.model('npn', 'NPN', bf=100)
     return circuit
@@ -29,12 +34,14 @@ def fuzz_circuit(dc_voltage=9@u_V):
 def overdrive_circuit(dc_voltage=9@u_V):
     """A simple diode clipping overdrive."""
     circuit = Circuit('Overdrive')
-    circuit.V(1, 'in', circuit.gnd, 0@u_V)
+    # See fuzz_circuit() above for why we omit a fixed DC source on the input.
     circuit.V(2, 'batt', circuit.gnd, dc_voltage)
     circuit.R(1, 'in', 'n1', 1@u_kOhm)
     circuit.R(2, 'n1', circuit.gnd, 1@u_kOhm)
     circuit.D(1, 'n1', 'out', model='d1')
     circuit.D(2, 'out', 'n1', model='d1')
+    # Add a high value load to ground so the output node is defined.
+    circuit.R('load', 'out', circuit.gnd, 100@u_kOhm)
     circuit.model('d1', 'D', Is=1e-15, N=1)
     return circuit
 


### PR DESCRIPTION
## Summary
- remove DC voltage sources from input nodes
- add load resistors to ground so `out` isn't floating

## Testing
- `python -m guitarpedals.simulate` *(fails: Command 'run' failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876a4402a988321800b47ad1ad68fd4