### PR TITLE
Restore FluidSynth usage and clean simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project demonstrates how to combine analog circuit simulation using **PySpi
 pip install -r requirements.txt
 ```
 
-PySpice depends on **ngspice**. On many systems it can be installed via package manager (e.g. `apt-get install ngspice`).
+PySpice depends on **ngspice**. On many systems it can be installed via a package manager (e.g. `apt-get install ngspice`). Rendering MIDI to audio requires the optional `pyfluidsynth` package and an installed FluidSynth library.
 
 ## Usage
 

--- a/guitarpedals/simulate.py
+++ b/guitarpedals/simulate.py
@@ -30,11 +30,7 @@ def simulate_circuit(circuit, input_wave, fs, target_fs=8000):
     orig_len = len(input_wave)
     orig_fs = fs
     if target_fs and fs > target_fs:
-        try:
-            input_wave = librosa.resample(np.asarray(input_wave), orig_sr=fs, target_sr=target_fs)
-        except Exception:
-            n_samples = int(len(input_wave) * target_fs / fs)
-            input_wave = signal.resample(input_wave, n_samples)
+        input_wave = librosa.resample(np.asarray(input_wave), orig_sr=fs, target_sr=target_fs)
         fs = target_fs
 
     step = 1 / fs @ u_s
@@ -44,7 +40,7 @@ def simulate_circuit(circuit, input_wave, fs, target_fs=8000):
     values = [(t @ u_s, float(v) @ u_V) for t, v in zip(times, input_wave)]
 
     circuit.PieceWiseLinearVoltageSource(
-        'input', 'in', circuit.gnd, values=values, dc=0 @ u_V
+        'input', 'in', circuit.gnd, values=values, dc=float(input_wave[0]) @ u_V
     )
 
     simulator = circuit.simulator(temperature=25, nominal_temperature=25)
@@ -53,10 +49,7 @@ def simulate_circuit(circuit, input_wave, fs, target_fs=8000):
 
     # Resample back to the original sampling rate if we changed it
     if fs != orig_fs:
-        try:
-            out = librosa.resample(out, orig_sr=fs, target_sr=orig_fs)
-        except Exception:
-            out = signal.resample(out, orig_len)
+        out = librosa.resample(out, orig_sr=fs, target_sr=orig_fs)
         fs = orig_fs
 
     return out

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy
 matplotlib
 soundfile
 librosa
+pyfluidsynth


### PR DESCRIPTION
## Summary
- use `pretty_midi.fluidsynth` again for MIDI rendering
- remove try/except blocks from `simulate_circuit`
- set DC value of piecewise linear source to match the first sample
- document FluidSynth requirement
- add `pyfluidsynth` to requirements

## Testing
- `pip install -r requirements.txt`
- `pip install setuptools`
- `apt-get install -y fluidsynth`
- `python -m guitarpedals.simulate` *(fails: cannot load library 'libngspice.so')*

------
https://chatgpt.com/codex/tasks/task_e_6876befee18c832197c3508cd0da6c78