### PR TITLE
Add schemdraw schematic generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ This will:
 
 1. Generate a short guitar riff and save it to `outputs/riff.wav`.
 2. Simulate the fuzz pedal circuit and create `outputs/fuzz.wav`.
-3. Plot the first part of the resulting waveform to `outputs/fuzz_waveform.png`.
+3. Generate a schematic of the circuit at `outputs/fuzz_schematic.png`.
+4. Plot the first part of the resulting waveform to `outputs/fuzz_waveform.png`.
 
 You can modify the code in `guitarpedals/generate.py` to load your own MIDI file or adjust the riff generation parameters.
 
@@ -42,6 +43,7 @@ After running `python -m guitarpedals.simulate`, the `outputs` directory will co
 
 - `riff.wav` – the clean, generated guitar riff
 - `fuzz.wav` – the same riff processed by the fuzz pedal simulation
+- `fuzz_schematic.png` – schematic diagram of the fuzz circuit
 - `fuzz_waveform.png` – plot of the first few milliseconds of the processed audio
 
 Listen to the WAV files and open the plot image to observe how the analog circuit model affects the waveform.

--- a/guitarpedals/simulate.py
+++ b/guitarpedals/simulate.py
@@ -9,7 +9,12 @@ import librosa
 
 from .generate import generate_riff
 from .dsp import normalize, low_pass
-from .circuits import fuzz_circuit, overdrive_circuit, save_circuit_diagram
+from .circuits import (
+    fuzz_circuit,
+    overdrive_circuit,
+    save_circuit_diagram,
+    save_circuit_schematic,
+)
 
 setup_logging()
 
@@ -85,8 +90,8 @@ def main():
     plt.savefig("outputs/input_waveform.png")
 
     circuit = fuzz_circuit()
-    circuit_img = f"outputs/{circuit.title.lower()}_circuit.png"
-    save_circuit_diagram(circuit, circuit_img)
+    circuit_img = f"outputs/{circuit.title.lower()}_schematic.png"
+    save_circuit_schematic(circuit, circuit_img)
     y = simulate_circuit(circuit, audio, fs)
     y = normalize(low_pass(y, fs))
     sf.write('outputs/fuzz.wav', y, fs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 soundfile
 librosa
 pyfluidsynth
+schemdraw


### PR DESCRIPTION
## Summary
- add schemdraw dependency
- generate professional schematics with schemdraw
- update simulate script to use new schematic function
- document new output file in README

## Testing
- `pip install -r requirements.txt`
- `python -m guitarpedals.simulate` *(fails: ImportError: fluidsynth is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876d88f99b08321a07bfa953d8cd1ca