### PR TITLE
Add CLI with advanced circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,29 +22,27 @@ PySpice depends on **ngspice**. On many systems it can be installed via a packag
 
 ## Usage
 
-Run the main simulation script:
+Use the provided command line interface to generate a test riff:
 
 ```bash
-python -m guitarpedals.simulate
+python -m guitarpedals.cli generate
 ```
 
-This will:
+Then process the riff with one of the available circuits, for example:
 
-1. Generate a short guitar riff and save it to `outputs/riff.wav`.
-2. Simulate the fuzz pedal circuit and create `outputs/fuzz.wav`.
-3. Generate a schematic of the circuit at `outputs/fuzz_schematic.png`.
-4. Plot the first part of the resulting waveform to `outputs/fuzz_waveform.png`.
+```bash
+python -m guitarpedals.cli simulate --circuit twostagefuzz --oversample 2
+```
 
-You can modify the code in `guitarpedals/generate.py` to load your own MIDI file or adjust the riff generation parameters.
+This writes the processed audio to `outputs/out.wav`, saves a schematic image and optionally applies convolution reverb with `--reverb-ir path/to/impulse.wav`.
 
 ## Expected Results
 
-After running `python -m guitarpedals.simulate`, the `outputs` directory will contain:
+After running `python -m guitarpedals.cli simulate`, the `outputs` directory will contain:
 
 - `riff.wav` – the clean, generated guitar riff
-- `fuzz.wav` – the same riff processed by the fuzz pedal simulation
-- `fuzz_schematic.png` – schematic diagram of the fuzz circuit
-- `fuzz_waveform.png` – plot of the first few milliseconds of the processed audio
+- `out.wav` – the riff processed by the selected circuit
+- `<circuit>_schematic.png` – schematic diagram of the chosen circuit
 
 Listen to the WAV files and open the plot image to observe how the analog circuit model affects the waveform.
 
@@ -57,7 +55,7 @@ src/
     circuits.py      # PySpice circuit definitions
     dsp.py           # DSP helper functions
     generate.py      # Guitar riff generation
-    simulate.py      # Main script to run simulation
+    cli.py           # Command line interface
 outputs/              # Created automatically for results
 ```
 

--- a/guitarpedals/circuits.py
+++ b/guitarpedals/circuits.py
@@ -50,6 +50,27 @@ def overdrive_circuit(dc_voltage=9 @ u_V):
     return circuit
 
 
+def two_stage_fuzz_circuit(dc_voltage=9 @ u_V):
+    """A simple two-transistor fuzz similar to classic fuzz pedals."""
+    circuit = Circuit("TwoStageFuzz")
+    circuit.V(2, "batt", circuit.gnd, dc_voltage)
+
+    circuit.R(1, "in", "b1", 33 @ u_kOhm)
+    circuit.R(2, "b1", "c1", 100 @ u_kOhm)
+    circuit.R(3, "c1", circuit.gnd, 10 @ u_kOhm)
+    circuit.BJT(1, "c1", "b1", circuit.gnd, model="npn")
+
+    circuit.R(4, "c1", "b2", 33 @ u_kOhm)
+    circuit.R(5, "b2", "c2", 100 @ u_kOhm)
+    circuit.R(6, "c2", circuit.gnd, 10 @ u_kOhm)
+    circuit.BJT(2, "c2", "b2", circuit.gnd, model="npn")
+
+    circuit.C(1, "c2", "out", 0.1 @ u_uF)
+    circuit.R("load", "out", circuit.gnd, 100 @ u_kOhm)
+    circuit.model("npn", "NPN", bf=100)
+    return circuit
+
+
 def save_circuit_diagram(circuit, filename):
     """Save a very simple diagram of ``circuit`` using Graphviz.
 
@@ -123,6 +144,32 @@ def save_circuit_schematic(circuit, filename):
             d.add(elm.Diode(label="D1").right())
             out = d.add(elm.Dot())
             d.add(elm.Diode(label="D2").right().at(out).reverse())
+            d.add(elm.Line().right())
+            d.add(elm.Resistor(label="100kΩ").down())
+            d.add(elm.Ground())
+        return
+
+    if title == "twostagefuzz":
+        with schemdraw.Drawing(file=filename) as d:
+            d.config(unit=2.0, fontsize=12)
+            d.add(elm.SourceSin(label="Vin"))
+            d.add(elm.Line().right())
+            d.add(elm.Resistor(label="33kΩ"))
+            d.add(elm.Dot())
+            q1 = d.add(elm.BjtNpn())
+            d.add(elm.Resistor(label="10kΩ").down().at(q1.collector))
+            d.add(elm.Ground())
+            d.add(elm.Line().up().at(q1.base))
+            d.add(elm.Resistor(label="100kΩ").to(q1.collector))
+            d.add(elm.Line().up().right())
+            d.add(elm.Resistor(label="33kΩ"))
+            d.add(elm.Dot())
+            q2 = d.add(elm.BjtNpn())
+            d.add(elm.Resistor(label="10kΩ").down().at(q2.collector))
+            d.add(elm.Ground())
+            d.add(elm.Line().up().at(q2.base))
+            d.add(elm.Resistor(label="100kΩ").to(q2.collector))
+            d.add(elm.Capacitor(label="0.1µF").right().at(q2.collector))
             d.add(elm.Line().right())
             d.add(elm.Resistor(label="100kΩ").down())
             d.add(elm.Ground())

--- a/guitarpedals/cli.py
+++ b/guitarpedals/cli.py
@@ -1,0 +1,79 @@
+import argparse
+import os
+import soundfile as sf
+import librosa
+
+from .generate import generate_riff
+from .simulate import simulate_circuit
+from .dsp import normalize, low_pass, oversample, downsample, convolution_reverb
+from .circuits import (
+    fuzz_circuit,
+    overdrive_circuit,
+    two_stage_fuzz_circuit,
+    save_circuit_schematic,
+)
+
+CIRCUITS = {
+    "fuzz": fuzz_circuit,
+    "overdrive": overdrive_circuit,
+    "two_stage_fuzz": two_stage_fuzz_circuit,
+}
+
+
+def load_audio(path):
+    data, sr = sf.read(path)
+    return data, sr
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Guitar pedal simulations")
+    sub = parser.add_subparsers(dest="command")
+
+    gen = sub.add_parser("generate", help="Generate a test riff")
+    gen.add_argument("--duration", type=float, default=4.0, help="Length of riff in seconds")
+
+    sim = sub.add_parser("simulate", help="Simulate a circuit on an audio file")
+    sim.add_argument("--input", default="outputs/riff.wav", help="Input WAV file")
+    sim.add_argument("--circuit", choices=list(CIRCUITS), default="fuzz", help="Circuit to simulate")
+    sim.add_argument("--output", default="outputs/out.wav", help="Output WAV file")
+    sim.add_argument("--reverb-ir", help="Impulse response WAV for convolution reverb")
+    sim.add_argument("--oversample", type=int, default=1, help="Oversampling factor")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "generate":
+        os.makedirs("outputs", exist_ok=True)
+        generate_riff(duration=args.duration)
+        return
+
+    if args.command == "simulate":
+        if not os.path.exists(args.input):
+            parser.error(f"Input file '{args.input}' not found")
+        audio, fs = load_audio(args.input)
+        circuit = CIRCUITS[args.circuit]()
+        save_circuit_schematic(circuit, f"outputs/{circuit.title.lower()}_schematic.png")
+
+        if args.oversample > 1:
+            audio = oversample(audio, args.oversample)
+            fs *= args.oversample
+
+        y = simulate_circuit(circuit, audio, fs)
+
+        if args.oversample > 1:
+            y = downsample(y, args.oversample)
+
+        if args.reverb_ir:
+            ir, ir_fs = load_audio(args.reverb_ir)
+            if ir_fs != fs:
+                ir = librosa.resample(ir, orig_sr=ir_fs, target_sr=fs)
+            y = convolution_reverb(y, ir)
+
+        y = normalize(low_pass(y, fs))
+        sf.write(args.output, y, fs)
+        return
+
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/guitarpedals/dsp.py
+++ b/guitarpedals/dsp.py
@@ -13,3 +13,23 @@ def normalize(x):
 def low_pass(x, sr, cutoff=5000):
     b, a = signal.butter(2, cutoff / (sr/2), btype='low')
     return signal.lfilter(b, a, x)
+
+
+def oversample(x, factor=2):
+    """Upsample ``x`` by ``factor`` using polyphase filtering."""
+    if factor <= 1:
+        return x
+    return signal.resample_poly(x, factor, 1)
+
+
+def downsample(x, factor=2):
+    """Downsample ``x`` by ``factor`` using polyphase filtering."""
+    if factor <= 1:
+        return x
+    return signal.resample_poly(x, 1, factor)
+
+
+def convolution_reverb(x, ir):
+    """Apply convolution reverb using impulse response ``ir``."""
+    y = signal.fftconvolve(x, ir, mode="full")
+    return y[: len(x)]


### PR DESCRIPTION
## Summary
- add a command line interface for generating riffs and running simulations
- implement oversampling and convolution reverb helpers
- create a new two-stage fuzz circuit
- document CLI usage in README

## Testing
- `pip install -q -r requirements.txt`
- `python -m guitarpedals.cli simulate --input test.wav --circuit fuzz --output out.wav` *(fails: libngspice.so not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876db6ea4e48321b46e36d238641293