### PR TITLE
Make output directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Then process the riff with one of the available circuits, for example:
 python -m guitarpedals.cli simulate --circuit twostagefuzz --oversample 2
 ```
 
-This writes the processed audio to `outputs/out.wav`, saves a schematic image and optionally applies convolution reverb with `--reverb-ir path/to/impulse.wav`.
+By default this writes the processed audio to `outputs/out.wav`, saves a schematic image and optionally applies convolution reverb with `--reverb-ir path/to/impulse.wav`. Use `--outdir DIR` to choose a different location for generated files.
 
 ## Expected Results
 
-After running `python -m guitarpedals.cli simulate`, the `outputs` directory will contain:
+After running `python -m guitarpedals.cli simulate`, the chosen output directory (default `outputs`) will contain:
 
 - `riff.wav` – the clean, generated guitar riff
 - `out.wav` – the riff processed by the selected circuit
@@ -56,7 +56,7 @@ src/
     dsp.py           # DSP helper functions
     generate.py      # Guitar riff generation
     cli.py           # Command line interface
-outputs/              # Created automatically for results
+outputs/              # Default directory for results
 ```
 
 Enjoy experimenting with analog-inspired guitar tones in the digital domain!

--- a/guitarpedals/generate.py
+++ b/guitarpedals/generate.py
@@ -3,7 +3,7 @@ import numpy as np
 import soundfile as sf
 
 
-def generate_riff(filename='outputs/riff.wav', midi_file=None, instrument_name='Electric Guitar (jazz)', duration=4.0, fs=44100):
+def generate_riff(filename='riff.wav', midi_file=None, instrument_name='Electric Guitar (jazz)', duration=4.0, fs=44100):
     """Generate a simple guitar riff and render to wav using FluidSynth."""
     if midi_file:
         pm = pretty_midi.PrettyMIDI(midi_file)

--- a/guitarpedals/simulate.py
+++ b/guitarpedals/simulate.py
@@ -79,28 +79,28 @@ def simulate_circuit(circuit, input_wave, fs, target_fs=8000):
     return out
 
 
-def main():
-    os.makedirs("outputs", exist_ok=True)
-    audio, fs = generate_riff()
+def main(outdir="outputs"):
+    os.makedirs(outdir, exist_ok=True)
+    audio, fs = generate_riff(os.path.join(outdir, "riff.wav"))
     audio = normalize(audio)
     plt.figure(figsize=(10, 4))
     plt.plot(audio)
     plt.title("Input Audio Waveform")
     plt.tight_layout()
-    plt.savefig("outputs/input_waveform.png")
+    plt.savefig(os.path.join(outdir, "input_waveform.png"))
 
     circuit = fuzz_circuit()
-    circuit_img = f"outputs/{circuit.title.lower()}_schematic.png"
+    circuit_img = os.path.join(outdir, f"{circuit.title.lower()}_schematic.png")
     save_circuit_schematic(circuit, circuit_img)
     y = simulate_circuit(circuit, audio, fs)
     y = normalize(low_pass(y, fs))
-    sf.write('outputs/fuzz.wav', y, fs)
+    sf.write(os.path.join(outdir, 'fuzz.wav'), y, fs)
 
     plt.figure(figsize=(10, 4))
     plt.plot(y)
     plt.title("Fuzz Output")
     plt.tight_layout()
-    plt.savefig("outputs/fuzz_waveform.png")
+    plt.savefig(os.path.join(outdir, "fuzz_waveform.png"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--outdir` option to the CLI so results aren't forced into `outputs`
- update internal defaults to build paths using the selected directory
- adjust example helper functions to take output directory paths
- document the new option in the README

## Testing
- `python -m guitarpedals.cli --help`
- `python -m guitarpedals.cli generate --help`
- `python -m guitarpedals.cli simulate --help`
- `python -m compileall -q guitarpedals`

------
https://chatgpt.com/codex/tasks/task_e_6877a718156083218254d6861f3d8028