### PR TITLE
Add waveform plot saving and detailed CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ Then process the riff with one of the available circuits, for example:
 python -m guitarpedals.cli simulate --circuit twostagefuzz --oversample 2
 ```
 
-By default this writes the processed audio to `outputs/out.wav`, saves a schematic image and optionally applies convolution reverb with `--reverb-ir path/to/impulse.wav`. Use `--outdir DIR` to choose a different location for generated files.
+By default this writes the processed audio to `outputs/out.wav`, saves a schematic image and waveform plots and optionally applies convolution reverb with `--reverb-ir path/to/impulse.wav`. Use `--outdir DIR` to choose a different location for generated files.
+
+### Command-line arguments
+
+| Argument | Applies To | Description |
+|----------|------------|-------------|
+| `--outdir DIR` | both | Output directory for generated files |
+| `generate --duration SECONDS` | `generate` | Length of generated riff |
+| `simulate --input PATH` | `simulate` | Input WAV file (defaults to `outdir/riff.wav`) |
+| `simulate --circuit {fuzz,overdrive,two_stage_fuzz}` | `simulate` | Circuit model to apply |
+| `simulate --output PATH` | `simulate` | Output WAV file name |
+| `simulate --reverb-ir PATH` | `simulate` | Impulse response WAV for convolution reverb |
+| `simulate --oversample N` | `simulate` | Oversampling factor before simulation |
 
 ## Expected Results
 
@@ -43,6 +55,8 @@ After running `python -m guitarpedals.cli simulate`, the chosen output directory
 - `riff.wav` – the clean, generated guitar riff
 - `out.wav` – the riff processed by the selected circuit
 - `<circuit>_schematic.png` – schematic diagram of the chosen circuit
+- `riff_waveform.png` – plot of the generated riff
+- `output_waveform.png` – plot of the circuit output
 
 Listen to the WAV files and open the plot image to observe how the analog circuit model affects the waveform.
 

--- a/guitarpedals/cli.py
+++ b/guitarpedals/cli.py
@@ -3,6 +3,15 @@ import os
 import soundfile as sf
 import librosa
 
+from .dsp import (
+    normalize,
+    low_pass,
+    oversample,
+    downsample,
+    convolution_reverb,
+    save_waveform_plot,
+)
+
 from .generate import generate_riff
 from .simulate import simulate_circuit
 from .dsp import normalize, low_pass, oversample, downsample, convolution_reverb
@@ -50,7 +59,8 @@ def main(argv=None):
 
     if args.command == "generate":
         filename = os.path.join(outdir, "riff.wav")
-        generate_riff(filename=filename, duration=args.duration)
+        audio, _ = generate_riff(filename=filename, duration=args.duration)
+        save_waveform_plot(audio, os.path.join(outdir, "riff_waveform.png"), "Generated Riff")
         return
 
     if args.command == "simulate":
@@ -58,6 +68,7 @@ def main(argv=None):
         if not os.path.exists(input_path):
             parser.error(f"Input file '{input_path}' not found")
         audio, fs = load_audio(input_path)
+        save_waveform_plot(audio, os.path.join(outdir, "input_waveform.png"), "Input Riff")
         circuit = CIRCUITS[args.circuit]()
         save_circuit_schematic(circuit, os.path.join(outdir, f"{circuit.title.lower()}_schematic.png"))
 
@@ -79,6 +90,7 @@ def main(argv=None):
         output_path = args.output or os.path.join(outdir, "out.wav")
         y = normalize(low_pass(y, fs))
         sf.write(output_path, y, fs)
+        save_waveform_plot(y, os.path.join(outdir, "output_waveform.png"), f"{circuit.title} Output")
         return
 
     parser.print_help()

--- a/guitarpedals/dsp.py
+++ b/guitarpedals/dsp.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy import signal
+import matplotlib.pyplot as plt
 
 
 def normalize(x):
@@ -33,3 +34,14 @@ def convolution_reverb(x, ir):
     """Apply convolution reverb using impulse response ``ir``."""
     y = signal.fftconvolve(x, ir, mode="full")
     return y[: len(x)]
+
+
+def save_waveform_plot(x, filename, title=None):
+    """Save a simple waveform plot of ``x`` to ``filename``."""
+    plt.figure(figsize=(10, 4))
+    plt.plot(x)
+    if title:
+        plt.title(title)
+    plt.tight_layout()
+    plt.savefig(filename)
+    plt.close()


### PR DESCRIPTION
## Summary
- save waveform plots in the CLI `generate` and `simulate` commands
- expose a helper `save_waveform_plot` in `dsp.py`
- document CLI arguments in a new table in the README

## Testing
- `pip install graphviz`
- `python -m guitarpedals.cli simulate --help`

------
https://chatgpt.com/codex/tasks/task_e_6877c0c7d76083218ea91f423bc0731a